### PR TITLE
Fix order of Quick Reference table and a typo

### DIFF
--- a/src/miscellany.xml
+++ b/src/miscellany.xml
@@ -31,7 +31,7 @@
 
         <p>The <term>stash</term> is a <term>stack</term>, a last-in, first-out arrangment, like a stack of plates in a warmer in a cafeteria.  At any time you can <term>save</term> your changes in a dirty directory with the command <c>git stash save</c> and they are removed from the working directory, thus making the directory clean again, and are saved as a changese in the stash.  This great if you just want to wander off some place else in your repository and you will be right back to your work-in-progress.  So we talk of <q>stashing your changes</q> as a temporary measure.</p>
 
-        <p>When you are a begineer, the stash is very alluring.  Resist the siren call.  It is not a cure-all and there is usually a better way to juggle two things at once.  Remember the three branches of <xref ref="hero-heroine-edit" />?  Here are some notes (which will not explain everything carefully).  Since the stash manipulates the working directory all at once, you have less control than you do with commits, even if the stash seems less permanent.</p>
+        <p>When you are a beginner, the stash is very alluring.  Resist the siren call.  It is not a cure-all and there is usually a better way to juggle two things at once.  Remember the three branches of <xref ref="hero-heroine-edit" />?  Here are some notes (which will not explain everything carefully).  Since the stash manipulates the working directory all at once, you have less control than you do with commits, even if the stash seems less permanent.</p>
 
         <ul>
             <li>

--- a/src/quick-reference.xml
+++ b/src/quick-reference.xml
@@ -47,13 +47,13 @@
             </li>
 
             <li>
-                <p><c>git branch -d topic</c></p>
-                <p>The topic branch pointer is obsolete as it duplicates the master branch pointer.</p>
+                <p><c>git merge topic</c></p>
+                <p>Use a fast-forward merge to bring the topic branch into the master branch.</p>
             </li>
 
             <li>
-                <p><c>git merge topic</c></p>
-                <p>Use a fast-forward merge to bring the topic branch into the master branch.</p>
+                <p><c>git branch -d topic</c></p>
+                <p>The topic branch pointer is obsolete as it duplicates the master branch pointer.</p>
             </li>
 
             <li>

--- a/src/solo.xml
+++ b/src/solo.xml
@@ -19,7 +19,7 @@
             <title>Git Manages Changes</title>
 
             <statement>
-                <p><c>git</c> manages collections of changes to your files.  And it does so in linear sequences of incremental changes that are always consistent.</p>
+                <p><c>git</c> manages collections of changes to your files.  It does so in linear sequences of incremental changes that are always consistent.</p>
             </statement>
         </principle>
 


### PR DESCRIPTION
Three little changes:
1. Correct the order of the entries in the Quick Reference table.
2. Fix a typo in miscellany.xml
3. For the "Git manages change" principle, there are two possible interpretations:
   (a) "git manages collections of changes to your file" and 
        " It does so in linear sequences of incremental changes that are always consistent."
        are two statements of about equal importance.
    (b) The first sentence is the main point and the second one is a bit of additional information.
    For the life of me, I couldn't understand your intent. My best guess was (a), and I made
    a little change to implement that assumption. If (b) is your intent, I would change it to
    "... to your files, and it does so ...".
    This is analogous to restrictive versus nonrestrictive clauses.

Cheers,
Michael
 